### PR TITLE
Prepare for v1.0.0 (initial release for Micronaut 4)

### DIFF
--- a/buildSrc/src/main/groovy/io.micronaut.build.internal.chatbots-module.gradle
+++ b/buildSrc/src/main/groovy/io.micronaut.build.internal.chatbots-module.gradle
@@ -11,11 +11,9 @@ dependencies {
 }
 
 micronautBuild {
+    // new module, so no binary check
     binaryCompatibility {
-        enabled.set(true)
-        // TODO required for now. Remove after Micronaut 4 release
-        baselineVersion = "2.0.0-M5"
+        enabled.set(false)
     }
 }
-
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,12 +1,11 @@
-projectVersion=2.0.0-SNAPSHOT
+projectVersion=1.0.0-SNAPSHOT
 projectGroup=io.micronaut.chatbots
 
 title=Micronaut Chatbots
-projectDesc=Ease the creation of Telegram and Basecamp chatbots with the Micronaut Framework
+projectDesc=Ease the creation of ChatBots with the Micronaut Framework
 projectUrl=https://micronaut.io
 githubSlug=micronaut-projects/micronaut-chatbots
 developers=Sergio del Amo
-
 
 # If needed, set additional properties
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,17 +1,19 @@
 [versions]
 micronaut = "4.2.3"
-micronaut-docs = "2.0.0"
-groovy = "4.0.13"
+
+micronaut-aws = "4.2.3"
+micronaut-azure = "5.1.0"
+micronaut-docs = "2.0.1"
+micronaut-gcp = "5.3.0"
+micronaut-logging = "1.2.0"
+micronaut-serde = "2.5.1"
+micronaut-test = "4.1.1"
+micronaut-validation = "4.2.0"
+
+groovy = "4.0.17"
 spock = "2.3-groovy-4.0"
 kotlin = "1.9.22"
-micronaut-test = "4.0.0"
-micronaut-aws = "4.2.3"
-micronaut-gcp = "5.3.0"
-micronaut-serde = "2.5.1"
-micronaut-validation = "4.2.0"
-micronaut-azure = "5.1.0"
 
-micronaut-logging = "1.2.0"
 [libraries]
 # Core
 micronaut-core = { module = 'io.micronaut:micronaut-core-bom', version.ref = 'micronaut' }
@@ -26,10 +28,13 @@ micronaut-validation = { module = "io.micronaut.validation:micronaut-validation-
 
 groovy-json = { module = "org.apache.groovy:groovy-json" }
 
-jackson-annotations = { module = 'com.fasterxml.jackson.core:jackson-annotations' }
 azure-functions-java-library = { module = 'com.microsoft.azure.functions:azure-functions-java-library' }
-kotlin-stdlib-jdk8 = { module = "org.jetbrains.kotlin:kotlin-stdlib-jdk8" }
+
+jackson-annotations = { module = 'com.fasterxml.jackson.core:jackson-annotations' }
+
 junit-api = { module = "org.junit.jupiter:junit-jupiter-api" }
 junit-engine = { module = "org.junit.jupiter:junit-jupiter-engine" }
+
+kotlin-stdlib-jdk8 = { module = "org.jetbrains.kotlin:kotlin-stdlib-jdk8" }
 
 gradle-kotlin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,7 @@ micronaut = "4.2.3"
 
 micronaut-aws = "4.2.3"
 micronaut-azure = "5.1.0"
-micronaut-docs = "2.0.1"
+micronaut-docs = "2.0.0"
 micronaut-gcp = "5.3.0"
 micronaut-logging = "1.2.0"
 micronaut-serde = "2.5.1"


### PR DESCRIPTION
We have decided to release v1.0.0 for Micronaut 4, and remove 1.0.0-M1 from Micronaut 3.

We will change the Micronaut 4 platform to use 1.0.0 instead of 2.0.0-M6

This PR:

- Update versions to latest (and order more logically)
- Sets the version to 1.0.0-SNAPSHOT
- Disables the binary compat check again (will be re-enabled after release)